### PR TITLE
changed the extracting the file name in CTD processing

### DIFF
--- a/Data/DataNotYetUploadedToEDI/Raw_CTD/CTD_code/CTD_automation/process_CTD_file.R
+++ b/Data/DataNotYetUploadedToEDI/Raw_CTD/CTD_code/CTD_automation/process_CTD_file.R
@@ -22,7 +22,7 @@ process_CTD_file <- function(file,
   MAX_DEPTH <- 100 #9.3 for FCR, 11 for BVR
   AUTO_NAME <- TRUE 
   AUTO_FOLDER <- TRUE 
-  REP <- str_extract(file, "_S[0-9]+")
+  REP <- str_extract(file, "_S[0-9]+[a-z]+|_S[0-9]+") # get the ending of the file
   SN <- as.numeric(str_extract(location, "\\d{4}"))
   
   #trim ctd


### PR DESCRIPTION
Changed the str_extract line to include text at the end for casts that are tests or ones that we don't want to include in the seasonal csv